### PR TITLE
RA-395: changing SCM tags to do releases from Bamboo; importing refapp pom

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -11,4 +11,17 @@
 	<packaging>jar</packaging>
 	<name>Reference Metadata Module API</name>
 	<description>API project for ReferenceMetadata</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.openmrs.api</groupId>
+			<artifactId>openmrs-api</artifactId>
+			<type>jar</type>
+        </dependency>
+		<dependency>
+			<groupId>org.openmrs.api</groupId>
+			<artifactId>openmrs-api</artifactId>
+			<type>test-jar</type>
+		</dependency>
+	</dependencies>
 </project>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -19,16 +19,6 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.openmrs.web</groupId>
-            <artifactId>openmrs-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.openmrs.web</groupId>
-            <artifactId>openmrs-web</artifactId>
-			<classifier>tests</classifier>
-        </dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -52,37 +52,42 @@
     </dependencyManagement> 
 
 		<dependencies>
+            <dependency>
+                <groupId>org.openmrs.api</groupId>
+                <artifactId>openmrs-api</artifactId>
+            </dependency>
+
+            <dependency>
+                <groupId>org.openmrs.api</groupId>
+                <artifactId>openmrs-api</artifactId>
+                <classifier>tests</classifier>
+            </dependency>
+
 			<dependency>
 				<groupId>org.openmrs.web</groupId>
 				<artifactId>openmrs-web</artifactId>
 				<type>jar</type>
-				<scope>provided</scope>
 			</dependency>
 
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>emrapi-api-1.10</artifactId>
-                <scope>provided</scope>
             </dependency>
           <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>idgen-api</artifactId>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>metadatasharing-api</artifactId>
-                <scope>provided</scope>
             </dependency>
             <dependency>
             	<groupId>org.openmrs.module</groupId>
             	<artifactId>dataexchange-api</artifactId>
-            	<scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.openmrs</groupId>
                 <artifactId>event-api</artifactId>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.geronimo.specs</groupId>
@@ -94,33 +99,46 @@
             
             <!-- For testing -->
             <dependency>
+                <groupId>org.openmrs.test</groupId>
+                <artifactId>openmrs-test</artifactId>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>providermanagement-api</artifactId>
-                <scope>provided</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>reporting-api</artifactId>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>calculation-api</artifactId>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>serialization.xstream-api</artifactId>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.openmrs.module</groupId>
                 <artifactId>appframework-api</artifactId>
-                <scope>provided</scope>
             </dependency>
 
         </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 
 	<repositories>
 		<repository>


### PR DESCRIPTION
I spent hours trying to get a similar dependency tree. 

But as it was using the refapp pom as a parent pom, they are still very different. 

The tests are green, I was able to start a new refapp distro from scratch, I could recompile and deploy to the distro reference-application module. 
