### PR TITLE
[RA-1257]: built-in reports multiple rows reports test coverage

### DIFF
--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfUsers.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfUsers.java
@@ -82,7 +82,7 @@ public class ListOfUsers extends BaseReportManager {
 
 	private String getSQLQuery(){
 		StringBuilder stringBuilder = new StringBuilder();
-		stringBuilder.append("select username, uuid ");
+		stringBuilder.append("select username, date_created ");
 		stringBuilder.append("from users ");
 		stringBuilder.append("where retired = :retired; ");
 

--- a/api/src/test/java/org/openmrs/module/referencemetadata/reports/ListOfDiagnosisTest.java
+++ b/api/src/test/java/org/openmrs/module/referencemetadata/reports/ListOfDiagnosisTest.java
@@ -13,12 +13,20 @@
  */
 package org.openmrs.module.referencemetadata.reports;
 
+import org.hamcrest.Matcher;
+import org.junit.Assert;
 import org.openmrs.module.referencemetadata.reporting.reports.ListOfDiagnosis;
 import org.openmrs.module.reporting.common.DateUtil;
+import org.openmrs.module.reporting.dataset.DataSetRow;
+import org.openmrs.module.reporting.dataset.SimpleDataSet;
 import org.openmrs.module.reporting.evaluation.EvaluationContext;
 import org.openmrs.module.reporting.report.ReportData;
 import org.openmrs.module.reporting.report.manager.ReportManager;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.validation.constraints.AssertTrue;
+
+import static org.hamcrest.Matchers.contains;
 
 public class ListOfDiagnosisTest  extends ReportManagerTest {
 
@@ -37,7 +45,15 @@ public class ListOfDiagnosisTest  extends ReportManagerTest {
 	}
 
 	public void verifyData(ReportData data) {
-		/*SimpleDataSet dataSet = (SimpleDataSet) data.getDataSets().values().iterator().next();
-		Assert.assertThat(dataSet.getRows(), contains(hasData("TOTAL", 1L)));*/
+		SimpleDataSet dataSet = (SimpleDataSet) data.getDataSets().values().iterator().next();
+
+		Matcher<DataSetRow>[] expectedValues = new Matcher[2];
+		expectedValues[0] = hasData("NAME", "Vero");
+		expectedValues[1] = hasData("NAME", "Myalgia");
+		Assert.assertThat(dataSet.getRows(), contains(expectedValues));
+
+		expectedValues[0] = hasData("COUNT", 2L);
+		expectedValues[1] = hasData("COUNT", 1L);
+		Assert.assertThat(dataSet.getRows(), contains(expectedValues));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/referencemetadata/reports/ListOfProvidersTest.java
+++ b/api/src/test/java/org/openmrs/module/referencemetadata/reports/ListOfProvidersTest.java
@@ -14,11 +14,17 @@
 
 package org.openmrs.module.referencemetadata.reports;
 
+import org.hamcrest.Matcher;
+import org.junit.Assert;
 import org.openmrs.module.referencemetadata.reporting.reports.ListOfProviders;
+import org.openmrs.module.reporting.dataset.DataSetRow;
+import org.openmrs.module.reporting.dataset.SimpleDataSet;
 import org.openmrs.module.reporting.evaluation.EvaluationContext;
 import org.openmrs.module.reporting.report.ReportData;
 import org.openmrs.module.reporting.report.manager.ReportManager;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.hamcrest.Matchers.contains;
 
 public class ListOfProvidersTest extends ReportManagerTest {
 
@@ -38,7 +44,12 @@ public class ListOfProvidersTest extends ReportManagerTest {
 	}
 
 	public void verifyData(ReportData data) {
-		/*SimpleDataSet dataSet = (SimpleDataSet) data.getDataSets().values().iterator().next();
-		Assert.assertThat(dataSet.getRows(), contains(hasData("TOTAL", 1L)));*/
+		SimpleDataSet dataSet = (SimpleDataSet) data.getDataSets().values().iterator().next();
+		Matcher<DataSetRow>[] expectedValues = new Matcher[3];
+		expectedValues[0] = hasData("IDENTIFIER", "clerk");
+		expectedValues[1] = hasData("IDENTIFIER", "nurse");
+		expectedValues[2] = hasData("IDENTIFIER", "doctor");
+
+		Assert.assertThat(dataSet.getRows(), contains(expectedValues));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/referencemetadata/reports/ListOfUsersTest.java
+++ b/api/src/test/java/org/openmrs/module/referencemetadata/reports/ListOfUsersTest.java
@@ -14,11 +14,19 @@
 
 package org.openmrs.module.referencemetadata.reports;
 
+import org.hamcrest.Matcher;
+import org.junit.Assert;
 import org.openmrs.module.referencemetadata.reporting.reports.ListOfUsers;
+import org.openmrs.module.reporting.dataset.DataSetRow;
+import org.openmrs.module.reporting.dataset.SimpleDataSet;
 import org.openmrs.module.reporting.evaluation.EvaluationContext;
 import org.openmrs.module.reporting.report.ReportData;
 import org.openmrs.module.reporting.report.manager.ReportManager;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.sql.Timestamp;
+
+import static org.hamcrest.Matchers.contains;
 
 public class ListOfUsersTest extends ReportManagerTest {
 
@@ -38,14 +46,21 @@ public class ListOfUsersTest extends ReportManagerTest {
 	}
 
 	public void verifyData(ReportData data) {
-//      HOW TO CHECK FOR MULTIPLE ROWS?
-/*		SimpleDataSet dataSet = (SimpleDataSet) data.getDataSets().values().iterator().next();
-		Assert.assertThat(dataSet.getRows(), contains(hasData("USERNAME", null)));
-		Assert.assertThat(dataSet.getRows(), contains(hasData("USERNAME", "admin")));
-		Assert.assertThat(dataSet.getRows(), contains(hasData("USERNAME", "butch")));
+		SimpleDataSet dataSet = (SimpleDataSet) data.getDataSets().values().iterator().next();
+		Matcher<DataSetRow>[] dataSetRowMatcher = new Matcher[5];
+		dataSetRowMatcher[0] = hasData("USERNAME", null);
+		dataSetRowMatcher[1] = hasData("USERNAME", "admin");
+		dataSetRowMatcher[2] = hasData("USERNAME", "clerk");
+		dataSetRowMatcher[3] = hasData("USERNAME", "doctor");
+		dataSetRowMatcher[4] = hasData("USERNAME", "butch");
+		Assert.assertThat(dataSet.getRows(), contains(dataSetRowMatcher));
 
-		Assert.assertThat(dataSet.getRows(), contains(hasData("UUID", "A4F30A1B-5EB9-11DF-A648-37A07F9C90FB")));
-		Assert.assertThat(dataSet.getRows(), contains(hasData("UUID", "1010d442-e134-11de-babe-001e378eb67e")));
-		Assert.assertThat(dataSet.getRows(), contains(hasData("UUID", "c98a1558-e131-11de-babe-001e378eb67e")));*/
+		dataSetRowMatcher[0] = hasData("DATE_CREATED", Timestamp.valueOf("2005-01-01 00:00:00.0"));
+		dataSetRowMatcher[1] = hasData("DATE_CREATED", Timestamp.valueOf("2005-01-01 00:00:00.0"));
+		dataSetRowMatcher[2] = hasData("DATE_CREATED", Timestamp.valueOf("2017-05-18 22:49:32"));
+		dataSetRowMatcher[3] = hasData("DATE_CREATED", Timestamp.valueOf("2017-05-18 22:49:32"));
+		dataSetRowMatcher[4] = hasData("DATE_CREATED", Timestamp.valueOf("2008-08-15 15:57:09.0"));
+		Assert.assertThat(dataSet.getRows(), contains(dataSetRowMatcher));
+
 	}
 }

--- a/api/src/test/java/org/openmrs/module/referencemetadata/reports/ReportManagerTest.java
+++ b/api/src/test/java/org/openmrs/module/referencemetadata/reports/ReportManagerTest.java
@@ -131,6 +131,6 @@ public abstract class ReportManagerTest extends BaseModuleContextSensitiveTest {
 	 * @return true if a subclass wants to print out the report contents to System.out
 	 */
 	public boolean enableReportOutput() {
-		return true;
+		return false;
 	}
 }

--- a/api/src/test/resources/BuiltInReportsTestDataset.xml
+++ b/api/src/test/resources/BuiltInReportsTestDataset.xml
@@ -59,10 +59,18 @@
 	          uuid="12b340a0-b6e8-492a-b54f-e2473e126b89"
 	/>
 
-	<users user_id="1" system_id="admin" password="ffba0fa0e7638c1ed511d497cd24afc6a5bcf5231eb9661a87fe215201ba4ede020152a656f02f7ffa5ba34360fe4b0d1e237fe0efed8509fb087a1fadae437d"
+	<users user_id="1" system_id="admin" username="admin" password="ffba0fa0e7638c1ed511d497cd24afc6a5bcf5231eb9661a87fe215201ba4ede020152a656f02f7ffa5ba34360fe4b0d1e237fe0efed8509fb087a1fadae437d"
 	       salt="0ce631e430099bfb05c83cbac134f4ace05a178f642b252517bc60be24eb4c3d4240b0f4421915c894eb9443e7e66f64dc89f5ab47139c1201fb9015df17ec45"
-	       creator="1" date_created="2005-01-01 00:00:00"
+	       creator="1" date_created="2005-01-01 00:00:00" uuid="1c3db49d-440a-11e6-a65c-00e04c680037" person_id="52" retired="0"
 		/>
+	<users user_id="2" system_id="3-4" username="clerk" password="badf57362aa8ccf8748f6487f969239e5eaeae4b9e1d33f3d786f18a3425c0c5dfe61ba71bcc73f54fa43c73ffadadbb9e3da22a09e30185b91e9f30ff6b186f"
+	       salt="0795a362cfa116b3ef0aacb8ead7392b9dbdb1487cdf58011b8f6160ae08c116a65e26afd00bbf4ce540cd846a7b026b098b4a13ea0825cf17274629366e0407"
+	       creator="1" date_created="2017-05-18 22:49:32" uuid="4882dd60-0508-11e3-8ffd-0800200c9a66" person_id="53" retired="0"
+	/>
+	<users user_id="3" system_id="5-9" username="doctor" password="0fdc49601828ad08a025cdf8b654baf64bf45492b8bdb1c9a67bbe9d8417560c405b183a9997d1155449adcae68bfcd7f73e4fa156e6bba136ee730b46e62441"
+	       salt="a3f19a3e712db96dfc8cb1b04b9158876dfd83a52b0af53c8295edf1939c6651c35be916e7fb1ebcdbdad66f93edd61af00619ed50fefcd029d67cbc21c8b854"
+	       creator="1" date_created="2017-05-18 22:49:32" uuid="67bfd7f0-0508-11e3-8ffd-0800200c9a66" person_id="54" retired="0"
+	/>
 
 	<concept_class concept_class_id="4" name="Diagnosis" description="Conclusion drawn through findings" creator="1" date_created="2004-02-02 00:00:00" retired="0"
 	               uuid="8d4918b0-c2cc-11de-8d13-0010c6dffd0f"


### PR DESCRIPTION
Added the remaining tests for multiple row reports. Used the matcher in hamcrest to assert multiple values in a column. Added required test data to test-data.xml file

- [x] mvn clean install

