### PR TITLE
RA-1508 Added improvements to Number of Visits Report

### DIFF
--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/NumberOfVisits.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/NumberOfVisits.java
@@ -50,6 +50,8 @@ public class NumberOfVisits extends BaseReportManager {
 		List<Parameter> parameterArrayList = new ArrayList<Parameter>();
 		parameterArrayList.add(ReportingConstants.START_DATE_PARAMETER);
 		parameterArrayList.add(ReportingConstants.END_DATE_PARAMETER);
+		parameterArrayList.add(ReportingConstants.LOCATION_PARAMETER);
+		parameterArrayList.add(new Parameter("activeVisits", "Include Active Visits", Boolean.class));
 		return parameterArrayList;
 	}
 
@@ -89,10 +91,12 @@ public class NumberOfVisits extends BaseReportManager {
 
 	private String getSQLQuery(){
 		StringBuilder stringBuilder = new StringBuilder();
-		stringBuilder.append("select count(*) as Number_of_visits ");
-		stringBuilder.append("from visit v ");
-		stringBuilder.append("where v.date_started >= :startDate ");
-		stringBuilder.append("and v.date_stopped <= :endDate ");
+		stringBuilder.append("SELECT max(vt.name) as VisitType ,count(v.visit_id) as Count FROM visit v ");
+		stringBuilder.append("INNER JOIN visit_type vt ON v.visit_type_id=vt.visit_type_id ");
+		stringBuilder.append("WHERE v.location_id LIKE :location ");
+		stringBuilder.append("AND v.date_started >= :startDate ");
+		stringBuilder.append("AND (v.date_stopped <= :endDate OR True = :activeVisits) ");
+		stringBuilder.append("GROUP BY vt.visit_type_id ;");
 
 		return stringBuilder.toString();
 	}

--- a/api/src/test/java/org/openmrs/module/referencemetadata/reports/NumberOfVisitsTest.java
+++ b/api/src/test/java/org/openmrs/module/referencemetadata/reports/NumberOfVisitsTest.java
@@ -15,6 +15,7 @@
 package org.openmrs.module.referencemetadata.reports;
 
 import org.junit.Assert;
+import org.openmrs.Location;
 import org.openmrs.module.referencemetadata.reporting.reports.NumberOfVisits;
 import org.openmrs.module.reporting.common.DateUtil;
 import org.openmrs.module.reporting.dataset.SimpleDataSet;
@@ -40,11 +41,14 @@ public class NumberOfVisitsTest extends ReportManagerTest {
 		EvaluationContext context = new EvaluationContext();
 		context.addParameterValue("startDate", DateUtil.getDateTime(2017,6,17));
 		context.addParameterValue("endDate", DateUtil.getDateTime(2017,6,20));
+		context.addParameterValue("location", new Location(Location.LOCATION_UNKNOWN));
+		context.addParameterValue("activeVisits", Boolean.FALSE);
 		return context;
 	}
 
 	public void verifyData(ReportData data) {
 		SimpleDataSet dataSet = (SimpleDataSet) data.getDataSets().values().iterator().next();
-		Assert.assertThat(dataSet.getRows(), contains(hasData("NUMBER_OF_VISITS", 2L)));
+		Assert.assertThat(dataSet.getRows(), contains(hasData("VisitType", "Facility Visit")));
+		Assert.assertThat(dataSet.getRows(), contains(hasData("Count", 2L)));
 	}
 }


### PR DESCRIPTION
## Description ##

Reference Meta Data module has Visit report which can give a number of total visits for given date period. The content of that report doesn't enough for a better report. So the report has improved with following contents,

- Total Number of visits grouped by visit types.
- Users should able to get the visit report for all locations or a given location.
- Bar chart should be added into the bottom of the report as usual.
- Users can include and exclude the active visits in the report


## Ticket ## 
https://issues.openmrs.org/browse/RA-1508
