### PR TITLE
RA-1509 Improved Number of Visit Notes report

### DIFF
--- a/api/src/test/java/org/openmrs/module/referencemetadata/reports/NumberOfVisitNotesTest.java
+++ b/api/src/test/java/org/openmrs/module/referencemetadata/reports/NumberOfVisitNotesTest.java
@@ -14,6 +14,7 @@
 package org.openmrs.module.referencemetadata.reports;
 
 import org.junit.Assert;
+import org.openmrs.Location;
 import org.openmrs.module.referencemetadata.reporting.reports.NumberOfVisitNotes;
 import org.openmrs.module.reporting.common.DateUtil;
 import org.openmrs.module.reporting.dataset.SimpleDataSet;
@@ -37,11 +38,14 @@ public class NumberOfVisitNotesTest extends ReportManagerTest {
 		EvaluationContext context = new EvaluationContext();
 		context.addParameterValue("startDate", DateUtil.getDateTime(2017,6,17));
 		context.addParameterValue("endDate", DateUtil.getDateTime(2017,6,20));
+		context.addParameterValue("location", new Location(Location.LOCATION_UNKNOWN));
+		context.addParameterValue("activeVisits", Boolean.FALSE);
 		return context;
 	}
 
 	public void verifyData(ReportData data) {
 		SimpleDataSet dataSet = (SimpleDataSet) data.getDataSets().values().iterator().next();
-		Assert.assertThat(dataSet.getRows(), contains(hasData("NUMBER_OF_VISIT_NOTES", 1L)));
+		Assert.assertThat(dataSet.getRows(), contains(hasData("VisitType", "Facility Visit")));
+		Assert.assertThat(dataSet.getRows(), contains(hasData("Count", 1L)));
 	}
 }

--- a/api/src/test/resources/BuiltInReportsTestDataset.xml
+++ b/api/src/test/resources/BuiltInReportsTestDataset.xml
@@ -130,7 +130,7 @@
 	<encounter_type encounter_type_id="5" name="Visit Note" description="Encounter where a full or abbreviated examination is done, usually leading to a presumptive or confirmed diagnosis, recorded by the examining clinician."
 	                creator="1" date_created="2013-08-01 23:57:50" retired="0" uuid="d7151f82-c1f3-4152-a605-2f9ea7414a79"
 	/>
-	<encounter encounter_id="5" encounter_type="5" patient_id="51" location_id="1" form_id="1" encounter_datetime="2017-06-18 22:19:48" creator="1"
+	<encounter encounter_id="5" encounter_type="5" visit_id="1"  patient_id="51" location_id="1" form_id="1" encounter_datetime="2017-06-18 22:19:48" creator="1"
 	           date_created="2017-06-18 23:44:47" voided="0" uuid="fe949855-dafe-44b7-af2f-cb5fc1b961ec"
 	/>
 </dataset>


### PR DESCRIPTION
## Description ##

Reference Meta Data module has Visit Notes report which can give a number of total visit nots for given date period. The content of that report doesn't enough for a better report. So the report has improved with following contents,

- Total Number of visit notes grouped by visit types.
- Users should able to get the visit notes report for all locations or a given location.
- Bar chart should be added into the bottom of the report as usual.
- Users can include and exclude visit notes of the active visits in the report


## Ticket ## 
https://issues.openmrs.org/browse/RA-1509
