### PR TITLE
TRUNK-5670 | Make appointment scheduling as aware_of dependency

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -36,11 +36,14 @@
         <require_module version="${metadatadeployVersion}">
             org.openmrs.module.metadatadeploy
         </require_module>
-        <require_module version="${appointmentschedulingVersion}">
-            org.openmrs.module.appointmentscheduling
-        </require_module>
 	</require_modules>
 	<!-- / Required Modules -->
+
+        <aware_of_modules>
+            <aware_of_module version="${appointmentschedulingVersion}">
+                        org.openmrs.module.appointmentscheduling
+                </aware_of_module>
+        </aware_of_modules>
 	
 	<!-- Module Activator -->
 	<activator>${project.parent.groupId}.${project.parent.artifactId}.ReferenceMetadataActivator</activator>


### PR DESCRIPTION
As part of this PR, We have changed the `reference-metadata` module to have `appointmentscheduling` as an `aware_of_module` dependency instead of `required_dependency`.

Card: https://issues.openmrs.org/browse/RA-1631