### PR TITLE
RA-1637: Install and Extend from Appointments related role only when the modules are present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
- - oraclejdk8
+ - openjdk8


### PR DESCRIPTION
This PR enables the reference-metadata module to "Only create roles for AppointmentsScheduling and AppointmentSchedulingUI if these modules are present".

- [x] Create a method to create the appointment-scheduling specific role, invoke it only when the appointment-scheduling modules are present.

- [x] Move extension of `Doctor, Nurse, RegistrationClerk, SystemAdmin & HospitalAdmin` into different methods. These roles extend to appointment specific roles only when the `appointment-scheduling` modules are present.

- [x] Tested with a distribution that doesn't have AppointmentsScheduling and AppointmentSchedulingUI installed and it skips the creation of the roles.

- [x] Tested with a distribution that has AppointmentsScheduling and AppointmentSchedulingUI installed and it creates the roles.

Issue: https://issues.openmrs.org/browse/RA-1637