### PR TITLE
RA-1862: Built-in report managers to extend ReferenceApplicationReportManager.

### DIFF
--- a/api/src/main/java/org/openmrs/module/referencemetadata/ReferenceMetadataActivator.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/ReferenceMetadataActivator.java
@@ -44,7 +44,7 @@ import org.openmrs.module.metadatadeploy.api.MetadataDeployService;
 import org.openmrs.module.metadatadeploy.bundle.MetadataBundle;
 import org.openmrs.module.metadatamapping.MetadataTermMapping;
 import org.openmrs.module.metadatamapping.api.MetadataMappingService;
-import org.openmrs.module.reporting.report.manager.ReportManager;
+import org.openmrs.module.referencemetadata.reporting.reports.ReferenceApplicationReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.openmrs.util.OpenmrsConstants;
 
@@ -71,7 +71,7 @@ public class ReferenceMetadataActivator extends BaseModuleActivator {
         log.info("Started Reference Metadata module");
 
 	    //setup built-in reports from #org.openmrs.module.referenceapplication.reports
-	    ReportManagerUtil.setupAllReports(ReportManager.class);
+	    ReportManagerUtil.setupAllReports(ReferenceApplicationReportManager.class);
     }
 
 	private void installConcepts() {

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfDiagnosis.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfDiagnosis.java
@@ -9,21 +9,20 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.reporting.ReportingConstants;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class ListOfDiagnosis extends BaseReportManager {
+public class ListOfDiagnosis extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "500261e9-0e0c-4e66-95dd-1f67bce0b699";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfNewPatientRegistrations.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfNewPatientRegistrations.java
@@ -9,21 +9,20 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.reporting.ReportingConstants;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class ListOfNewPatientRegistrations extends BaseReportManager {
+public class ListOfNewPatientRegistrations extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "17f7658c-c915-4c32-adad-df3799855569";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfPatientsForADiagnosis.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfPatientsForADiagnosis.java
@@ -9,20 +9,20 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.reporting.ReportingConstants;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
-import java.util.ArrayList;
-import java.util.List;
 
 @Component
-public class ListOfPatientsForADiagnosis extends BaseReportManager  {
+public class ListOfPatientsForADiagnosis extends ReferenceApplicationReportManager  {
 
     private static final String DATA_SET_UUID = "500261e9-0e0e-4e66-95dd-1f67bce0b699";
     public static final Parameter DIAGNOSIS_UUID_PARAMETER = new Parameter("diagnosisUuid", "Diagnosis UUID", String.class);

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfPatientsForAProvider.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfPatientsForAProvider.java
@@ -9,19 +9,19 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
-import java.util.ArrayList;
-import java.util.List;
 
 @Component
-public class ListOfPatientsForAProvider extends BaseReportManager {
+public class ListOfPatientsForAProvider extends ReferenceApplicationReportManager {
 
     private static final String DATA_SET_UUID = "00fceb85-dcc8-42fc-baf7-0485516d19f5";
     public static final Parameter PROVIDER_UUID_PARAMETER = new Parameter("providerUuid", "Provider UUID", String.class);

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfProviders.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfProviders.java
@@ -9,20 +9,19 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class ListOfProviders extends BaseReportManager {
+public class ListOfProviders extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "bae94c6f-59ac-44e0-afa9-f8f8729d90b0";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfUsers.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ListOfUsers.java
@@ -9,20 +9,19 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class ListOfUsers extends BaseReportManager {
+public class ListOfUsers extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "6a26e06c-d38d-4470-abb7-86de417c1865";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/NumberOfPatientRegistrations.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/NumberOfPatientRegistrations.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.referencemetadata.reporting.definition.library.ReferenceApplicationCohortDefinitionLibrary;
 import org.openmrs.module.referencemetadata.reporting.definition.library.ReferenceApplicationPatientDataDefinitionLibrary;
 import org.openmrs.module.reporting.ReportingConstants;
@@ -20,16 +23,12 @@ import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class NumberOfPatientRegistrations extends BaseReportManager {
+public class NumberOfPatientRegistrations extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "cc96c6d5-1adf-4fb6-bc72-284f1822a9f3";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/NumberOfVisitNotes.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/NumberOfVisitNotes.java
@@ -9,21 +9,20 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.reporting.ReportingConstants;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class NumberOfVisitNotes extends BaseReportManager {
+public class NumberOfVisitNotes extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "ec726fb5-fee8-43c5-b85f-034d165c2fb3";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/NumberOfVisits.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/NumberOfVisits.java
@@ -9,21 +9,20 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.module.reporting.ReportingConstants;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Component
-public class NumberOfVisits extends BaseReportManager {
+public class NumberOfVisits extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "439828be-a96a-437a-af4d-7db1c03a259f";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ReferenceApplicationReportManager.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/ReferenceApplicationReportManager.java
@@ -1,0 +1,6 @@
+package org.openmrs.module.referencemetadata.reporting.reports;
+
+import org.openmrs.module.reporting.report.manager.BaseReportManager;
+
+public abstract class ReferenceApplicationReportManager extends BaseReportManager {
+}


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/RA-1862

#### What I have done:
All built-in report managers to extend the new `ReferenceApplicationReportManager` so that they can be filtered on that basis:
```java
ReportManagerUtil.setupAllReports(ReferenceApplicationReportManager.class);
```