### PR TITLE
RA-1862: ADT built-in report managers to extend ReferenceApplicationReportManager.

### DIFF
--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/admissions/NumberOfAdmissions.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/admissions/NumberOfAdmissions.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports.admissions;
 
+import org.openmrs.module.referencemetadata.reporting.reports.ReferenceApplicationReportManager;
 import org.openmrs.module.reporting.ReportingConstants;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class NumberOfAdmissions extends BaseReportManager {
+public class NumberOfAdmissions extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "f841b170-3ea6-4e5c-9c77-eb5b228f7e8f";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/admissions/NumberOfAllAdmissions.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/admissions/NumberOfAllAdmissions.java
@@ -14,19 +14,19 @@
 
 package org.openmrs.module.referencemetadata.reporting.reports.admissions;
 
+import org.openmrs.module.referencemetadata.reporting.reports.ReferenceApplicationReportManager;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class NumberOfAllAdmissions extends BaseReportManager {
+public class NumberOfAllAdmissions extends ReferenceApplicationReportManager {
 
     private static final String DATA_SET_UUID = "1db15456-95a9-4be4-96fd-9409ad8f3950";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/discharges/NumberOfAllDischarges.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/discharges/NumberOfAllDischarges.java
@@ -14,19 +14,19 @@
 
 package org.openmrs.module.referencemetadata.reporting.reports.discharges;
 
+import org.openmrs.module.referencemetadata.reporting.reports.ReferenceApplicationReportManager;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class NumberOfAllDischarges extends BaseReportManager {
+public class NumberOfAllDischarges extends ReferenceApplicationReportManager {
 
     private static final String DATA_SET_UUID = "f03c2413-3f8b-4bf8-93ec-6d48ce11a6e1";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/discharges/NumberOfDischarges.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/discharges/NumberOfDischarges.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports.discharges;
 
+import org.openmrs.module.referencemetadata.reporting.reports.ReferenceApplicationReportManager;
 import org.openmrs.module.reporting.ReportingConstants;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class NumberOfDischarges extends BaseReportManager {
+public class NumberOfDischarges extends ReferenceApplicationReportManager {
 
 	private static final String DATA_SET_UUID = "a6dd7f69-97cd-4789-b38c-f5c48c485d4b";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/transfers/NumberOfAllTransfers.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/transfers/NumberOfAllTransfers.java
@@ -14,19 +14,19 @@
 
 package org.openmrs.module.referencemetadata.reporting.reports.transfers;
 
+import org.openmrs.module.referencemetadata.reporting.reports.ReferenceApplicationReportManager;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class NumberOfAllTransfers extends BaseReportManager {
+public class NumberOfAllTransfers extends ReferenceApplicationReportManager {
 
     private static final String DATA_SET_UUID = "ce3b4d0b-2567-4362-97ad-5d1c7d856a23";
 

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/transfers/NumberOfTransfers.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/reports/transfers/NumberOfTransfers.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs.module.referencemetadata.reporting.reports.transfers;
 
+import org.openmrs.module.referencemetadata.reporting.reports.ReferenceApplicationReportManager;
 import org.openmrs.module.reporting.ReportingConstants;
 import org.openmrs.module.reporting.dataset.definition.SqlDataSetDefinition;
 import org.openmrs.module.reporting.evaluation.parameter.Mapped;
 import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.report.ReportDesign;
 import org.openmrs.module.reporting.report.definition.ReportDefinition;
-import org.openmrs.module.reporting.report.manager.BaseReportManager;
 import org.openmrs.module.reporting.report.manager.ReportManagerUtil;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
-public class NumberOfTransfers extends BaseReportManager {
+public class NumberOfTransfers extends ReferenceApplicationReportManager  {
 
 	private static final String DATA_SET_UUID = "b183ed6a-ecd0-43a8-b3f5-4f0066327cda";
 


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/RA-1862

#### What I have done:
Extending the new logic to ADT built-in reports.

BTW @mks-d @dkayiwa we should also change the tests to extend the  `ReferenceApplicationReportManagerTest` class.