### PR TITLE
Replace Arrays#asList with Collections.singletonList

### DIFF
--- a/api/src/main/java/org/openmrs/module/referencemetadata/ReferenceMetadataActivator.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/ReferenceMetadataActivator.java
@@ -16,7 +16,7 @@ package org.openmrs.module.referencemetadata;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
+import java.util.Collections;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -131,8 +131,8 @@ public class ReferenceMetadataActivator extends BaseModuleActivator {
     public void deployMetadataPackages(MetadataDeployService service) {
         MetadataBundle rolesAndPrivileges = Context.getRegisteredComponent("referenceApplicationRolesAndPrivileges", MetadataBundle.class);
 	    MetadataBundle orderFrequencies = Context.getRegisteredComponent("referenceApplicationOrderFrequencies", MetadataBundle.class);
-	    service.installBundles(Arrays.asList(rolesAndPrivileges));
-	    service.installBundles(Arrays.asList(orderFrequencies));
+	    service.installBundles(Collections.singletonList(rolesAndPrivileges));
+	    service.installBundles(Collections.singletonList(orderFrequencies));
     }
 
 	public void installMetadataPackages() {

--- a/api/src/main/java/org/openmrs/module/referencemetadata/reporting/definition/library/ReferenceApplicationPatientDataDefinitionLibrary.java
+++ b/api/src/main/java/org/openmrs/module/referencemetadata/reporting/definition/library/ReferenceApplicationPatientDataDefinitionLibrary.java
@@ -32,7 +32,7 @@ import org.openmrs.module.reporting.evaluation.parameter.Parameter;
 import org.openmrs.module.reporting.evaluation.parameter.ParameterizableUtil;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 
@@ -80,7 +80,7 @@ public class ReferenceApplicationPatientDataDefinitionLibrary extends BaseDefini
 		ConvertedPatientDataDefinition convertedDefinition = new ConvertedPatientDataDefinition();
 		convertedDefinition.setDefinitionToConvert(ParameterizableUtil.copyAndMap(pdd, convertedDefinition, renamedParameters));
 		if (converter != null) {
-			convertedDefinition.setConverters(Arrays.asList(converter));
+			convertedDefinition.setConverters(Collections.singletonList(converter));
 		}
 		return convertedDefinition;
 	}


### PR DESCRIPTION
This fixes the `com.thoughtworks.xstream.converters.ConversionException: No converter available` error when running the 2.x snapshot.


Related ticket: https://openmrs.atlassian.net/browse/SXS-37